### PR TITLE
Consistent sampling

### DIFF
--- a/opentelemetry_hook_sampler/__init__.py
+++ b/opentelemetry_hook_sampler/__init__.py
@@ -41,6 +41,7 @@ class HookSampler(TraceIdRatioBased):
         if sample_rate:
             self._bound = self.get_bound_for_rate(1 / sample_rate)
         else:
+            sample_rate = 0
             self._bound = self.get_bound_for_rate(0)
 
         # make sampling decision

--- a/opentelemetry_hook_sampler/__init__.py
+++ b/opentelemetry_hook_sampler/__init__.py
@@ -13,6 +13,16 @@ from opentelemetry.util.types import Attributes
 
 
 class HookSampler(TraceIdRatioBased):
+    """
+    Sampler that makes sampling decisions probabilistically based on a rate
+    given by the `hook` function.
+
+    Args:
+        hook: A function that must return an int N to sample 1/N times.
+            Use `rate=0`, `rate=None`, or any falsy value to drop the span.
+            Use `rate=1` to always record the span.
+    """
+
     def __init__(self, hook: callable):
         self._hook = hook
 
@@ -50,12 +60,22 @@ class HookSampler(TraceIdRatioBased):
 
 
 class ParentBasedHookSampler(ParentBased):
+    """
+    Sampler that respects its parent span's sampling decision, but otherwise
+    samples probabilistically based on a rate given by the `hook` function.
+    """
+
     def __init__(self, hook: callable):
         root = HookSampler(hook=hook)
         super().__init__(root=root)
 
 
 class HoneycombMixin:
+    """
+    Mixin that adds the vendor-specific attribute `SampleRate` based on TraceState.
+    The `SampleRate` attribute is used by Honeycomb to show the adjusted count.
+    """
+
     def should_sample(
         self,
         parent_context: Optional[Context],
@@ -83,8 +103,20 @@ class HoneycombMixin:
 
 
 class HoneycombHookSampler(HoneycombMixin, HookSampler):
+    """
+    Sampler that makes sampling decisions probabilistically based on a rate
+    given by the `hook` function. Also, saves the rate as an attribute that
+    Honeycomb uses to show the adjusted count.
+    """
+
     pass
 
 
 class ParentBasedHoneycombHookSampler(HoneycombMixin, ParentBasedHookSampler):
+    """
+    Sampler that respects its parent span's sampling decision, but otherwise samples
+    probabilistically based on a rate given by the `hook` function. Also, saves the
+    rate as an attribute that Honeycomb uses to show the adjusted count.
+    """
+
     pass

--- a/opentelemetry_hook_sampler/test_multiple_spans.py
+++ b/opentelemetry_hook_sampler/test_multiple_spans.py
@@ -1,0 +1,98 @@
+from unittest.mock import Mock
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace.sampling import Decision
+
+from opentelemetry_hook_sampler import (
+    ParentBasedHoneycombHookSampler,
+    ParentBasedHookSampler,
+)
+
+
+@pytest.mark.parametrize(
+    "SamplerClass",
+    [
+        ParentBasedHookSampler,
+        ParentBasedHoneycombHookSampler,
+    ],
+)
+def test_parent_based_sampled(SamplerClass):
+    never_hook = Mock(return_value=0)
+    sampler = SamplerClass(never_hook)
+    parent_context = trace.set_span_in_context(
+        trace.NonRecordingSpan(
+            trace.SpanContext(
+                0x1234,
+                0x5678,
+                is_remote=False,
+                trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+            )
+        )
+    )
+
+    result = sampler.should_sample(
+        parent_context,
+        0x8000000000000000,
+        "span name",
+        attributes={"foo": "bar"},
+    )
+
+    assert result.decision == Decision.RECORD_AND_SAMPLE
+    assert result.attributes["foo"] == "bar"
+
+
+@pytest.mark.parametrize(
+    "SamplerClass",
+    [
+        ParentBasedHookSampler,
+        ParentBasedHoneycombHookSampler,
+    ],
+)
+def test_parent_based_dropped(SamplerClass):
+    always_hook = Mock(return_value=1)
+    sampler = SamplerClass(always_hook)
+    parent_context = trace.set_span_in_context(
+        trace.NonRecordingSpan(
+            trace.SpanContext(
+                0x1234,
+                0x5678,
+                is_remote=False,
+                trace_flags=trace.TraceFlags(trace.TraceFlags.DEFAULT),
+            )
+        )
+    )
+
+    result = sampler.should_sample(
+        parent_context,
+        0x8000000000000000,
+        "span name",
+        attributes={"foo": "bar"},
+    )
+
+    assert result.decision == Decision.DROP
+    assert result.attributes == {}
+
+
+def test_parent_based_honeycomb_sample_rate_attribute():
+    hook = Mock()
+    sampler = ParentBasedHoneycombHookSampler(hook)
+    parent_context = trace.set_span_in_context(
+        trace.NonRecordingSpan(
+            trace.SpanContext(
+                0x1234,
+                0x5678,
+                is_remote=False,
+                trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+                trace_state=trace.TraceState([("sample_rate", "42")]),
+            )
+        )
+    )
+
+    result = sampler.should_sample(
+        parent_context,
+        0x8000000000000000,
+        "span name",
+    )
+
+    assert result.attributes["SampleRate"] == "42"

--- a/opentelemetry_hook_sampler/test_single_span.py
+++ b/opentelemetry_hook_sampler/test_single_span.py
@@ -160,8 +160,8 @@ def test_description_honeycomb_hook_sampler():
     ],
 )
 def test_honeycomb_sample_rate_attribute(SamplerClass):
-    always_hook = Mock(return_value=42)
-    sampler = SamplerClass(always_hook)
+    partial_hook = Mock(return_value=42)
+    sampler = SamplerClass(partial_hook)
 
     result = sampler.should_sample(
         None,


### PR DESCRIPTION
Solves 2 problems:

1. Sampling was not consistent. This makes it easier to sample some spans of a trace and others not, and prevents distributed tracing from working. Fixed by basing sample decision on `trace_id`, which is the same for all spans, including distributed ones.
2. `SampleRate` was only set on the span that ran `HoneycombHookSampler`, breaking Honeycomb adjusted count. Fixed by saving rate on the TraceState and setting `SampleRate` attribute on all spans of the trace.

Loosely based on: https://opentelemetry.io/docs/reference/specification/trace/tracestate-probability-sampling/

To-do:

- [x] fix broken tests
- [x] add tests for scenarios solved
